### PR TITLE
added support to arbitrary properties by removing backticks

### DIFF
--- a/ox-ravel.org
+++ b/ox-ravel.org
@@ -937,7 +937,8 @@ stripped on output. Interior backticks will not be affected.
   (defun ox-ravel--format-cell-opts ( arglist &optional comment)
     "Convert ARGLIST to commented YAML syntax."
     (mapconcat
-     (lambda( argmnt ) (concat (or comment "#") "| " (car argmnt) ": "
+     (lambda( argmnt ) (concat (or comment "#") "| "
+			       (org-unbracket-string "`" "`" (car argmnt)) ": "
 			       ;; strip enclosing backticks
 			       (org-unbracket-string "`" "`" (cdr argmnt))))
      arglist


### PR DESCRIPTION
I noticed that I could not add the quarto property code-fold and that had to use backticks for it to show up. So I made a small change also remove the backticks from the property names. So far it seem to work fine.